### PR TITLE
Simplify motion profiles to single stage and add continuity test

### DIFF
--- a/config/tv3_baseline.json
+++ b/config/tv3_baseline.json
@@ -4,22 +4,16 @@
   "step_size_mm": 0.005,
   "array_height_mm": 5.0,
   "index_time_s": 0.06,
-  "settle_linear_s": 0.29,
-  "settle_stepper_s": 0.050,
+  "settle_time_s": 0.29,
   "comms_overhead_s": 0.156,
-  "linear_motor": {
+  "stage": {
     "max_velocity": 5,
     "max_acceleration": 25,
     "jerk_max": 40000
-  },
-  "stepper_motor": {
-    "max_velocity": 1,
-    "max_acceleration": 200,
-    "jerk_max": 10000
   },
   "velocity_sweep": [1, 20, 20],
   "acceleration_sweep": [5, 100, 20],
   "velocity_2d_sweep": [1, 20, 1],
   "acceleration_2d_sweep": [5, 100, 5],
-  "notes": "TV3 baseline system config; classic 10mm scan, 5um step, typical timing values."
+  "notes": "TV3 baseline system config; classic 10mm scan, 5um step."
 }

--- a/data/stage_data.csv
+++ b/data/stage_data.csv
@@ -8,7 +8,3 @@ Linear,Griffin Motion CXY-C-100-BS-A-M-P,150,50
 Linear,Griffin Motion NPS-110-LM-G-HH…,300,50
 Linear,Novanta nPL70L-4M,2500,50
 Linear,Standa 8MTL120,1000,50
-Stepper,Zaber LSM100B-T4A,104,1000
-Stepper,Standa 8MTF,10,1000
-Stepper,SIGMA KOKI OSMS26-100(XY),40,1000
-Stepper,Sigma Koki VAAB292,20,1000

--- a/scripts/motion_profile.py
+++ b/scripts/motion_profile.py
@@ -12,17 +12,10 @@ class MotionProfile:
     color: str = "blue"
 
 
-# Example profiles used in notebooks or quick tests
-linear_motor = MotionProfile(
-    name="Linear Motor",
+# Example profile used in notebooks or quick tests
+stage_profile = MotionProfile(
+    name="Stage",
     max_velocity=300,
     max_acceleration=2000,
     color="blue",
-)
-
-stepper_motor = MotionProfile(
-    name="Stepper Motor",
-    max_velocity=50,
-    max_acceleration=8000,
-    color="orange",
 )

--- a/tests/test_velocity_continuity.py
+++ b/tests/test_velocity_continuity.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+import numpy as np
+from motion_profile import MotionProfile
+from simulator import ExperimentSimulator
+
+
+def test_velocity_continuity_after_accel():
+    profile = MotionProfile(name="Stage", max_velocity=5, max_acceleration=25, jerk_max=40000)
+    sim = ExperimentSimulator(
+        profile=profile,
+        scan_length=10,
+        step_size=0.005,
+        num_lines=1,
+        index_time=0.06,
+        overhead_per_line=0.156,
+    )
+    t, x, v, a, phase = sim.simulate_scurve_scan_with_backoff()
+    phase = np.array(phase)
+    accel_end = np.where(phase == "accel")[0][-1]
+    const_start = accel_end + 1
+    diff = abs(v[const_start] - v[accel_end])
+    assert diff < 1e-6


### PR DESCRIPTION
## Summary
- remove stepper motor references and use a single stage profile
- update configuration and stage data accordingly
- adjust simulations and sweeps for the new single-stage setup
- add automated test ensuring velocity continuity after acceleration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685af8044f74833297e54b0629e29952