### PR TITLE
Improve annotation offsets and timing precision

### DIFF
--- a/scripts/plotter.py
+++ b/scripts/plotter.py
@@ -55,19 +55,28 @@ def plot_single_cycle_breakdown_bar(breakdowns, profiles, out_dir):
 
     for row, (label, bd) in enumerate(zip(profile_labels, breakdowns)):
         start = 0.0
+        annot_positions = []
         for phase, color in zip(phase_labels, phase_colors):
             duration = bd[phase]
             ax.barh(row, duration, left=start, height=0.5, color=color)
+
+            x_center = start + duration / 2
+            base_y = row + 0.6
+            offset_count = sum(
+                1 for pos in annot_positions if abs(x_center - pos) < 0.05 * max_total
+            )
+            y_text = base_y + 0.3 * offset_count
             ax.annotate(
                 f"{phase}\n{duration:.2f}s",
-                xy=(start + duration / 2, row),
-                xytext=(start + duration / 2, row + 0.6),
+                xy=(x_center, row),
+                xytext=(x_center, y_text),
                 textcoords="data",
                 ha="center",
                 va="bottom",
                 fontsize=8,
                 arrowprops=dict(arrowstyle="->", lw=0.5, color="black"),
             )
+            annot_positions.append(x_center)
             start += duration
 
         ax.text(start + max_total * 0.02, row, f"{bd['Total']:.2f}s", va="center", ha="left", fontweight="bold")

--- a/scripts/simulator.py
+++ b/scripts/simulator.py
@@ -3,6 +3,14 @@ import math
 from motion_profile import MotionProfile
 
 
+def _time_array(duration: float, dt: float) -> np.ndarray:
+    """Return a time array from 0 to duration inclusive using step dt."""
+    arr = np.arange(0, duration, dt)
+    if not np.isclose(arr[-1], duration):
+        arr = np.append(arr, duration)
+    return arr
+
+
 def s_curve_to_velocity(v_end: float, amax: float, jmax: float, dt: float = 0.0005):
     """
     Generate a jerk-limited S-curve to accelerate from 0 to v_end.
@@ -21,9 +29,9 @@ def s_curve_to_velocity(v_end: float, amax: float, jmax: float, dt: float = 0.00
     t3 = t1
 
     # Time grids for each phase
-    t1_phase = np.arange(0, t1, dt)
-    t2_phase = np.arange(dt, t2, dt) if t2 > 0 else np.array([])
-    t3_phase = np.arange(0, t3, dt)
+    t1_phase = _time_array(t1, dt)
+    t2_phase = _time_array(t2, dt)[1:] if t2 > 0 else np.array([])
+    t3_phase = _time_array(t3, dt)
 
     # Phase 1: jerk up
     a1 = jmax * t1_phase


### PR DESCRIPTION
## Summary
- avoid stacked annotations in `plot_single_cycle_breakdown_bar`
- add helper `_time_array` for accurate S-curve timing
- ensure s-curve phase durations include final time step

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c3595b1ac83328f8f41f09d9f7f18